### PR TITLE
Fix building on python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,11 +61,7 @@ setup(
     install_requires=[
         'python-axolotl>=0.1.7',
         'pycrypto>=2.6.1',
+        'protobuf>=3.0.0b2'
     ],
-    extras_require={
-        # eg:
-        #   'rst': ['docutils>=0.11'],
-        #   ':python_version=="2.6"': ['argparse'],
-        'python_version > "3.0"': ['protobuf>=3.0.0b2']
-    },
+    extras_require={},
 )


### PR DESCRIPTION
We just depend on the most recent protobuf version. This works for
python 2 & 3.
