### PR TITLE
Monkey patch python-axolotl instead using a fork

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -2,5 +2,6 @@
 Usage
 =====
 
-When used on Python 3 it will install a customed patched version of
-python-axolotl from https://github.com/kalkin/python-axolotl
+To use Python OMEMO Library in a project::
+
+	import omemo

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ from setuptools import find_packages
 from setuptools import setup
 
 requirements = [
-        'python-axolotl==0.1.7-p1',
-        'protobuf==3.0.0.b2'
+        'python-axolotl>=0.1.7',
+        'protobuf>=3.0.0b2'
     ]
 
 if platform.python_implementation() == 'PyPy':
@@ -69,7 +69,6 @@ setup(
     keywords=[
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
-    extras_require={},
-    dependency_links=["https://github.com/kalkin/python-axolotl/tarball/master#egg=python-axolotl-0.1.7-p1"],
     install_requires=requirements,
-    )
+    extras_require={},
+)

--- a/src/omemo/aes_gcm.py
+++ b/src/omemo/aes_gcm.py
@@ -18,6 +18,7 @@
 #
 
 import os
+import sys
 
 try:
     from omemo.aes_gcm_native import aes_decrypt
@@ -38,7 +39,11 @@ def encrypt(plaintext):
 
 
 def decrypt(key, iv, ciphertext):
-    return aes_decrypt(key, iv, ciphertext).decode('utf-8')
+    plaintext = aes_decrypt(key, iv, ciphertext).decode('utf-8')
+    if sys.version_info < (3, 0):
+        return unicode(plaintext)
+    else:
+        return plaintext
 
 
 class NoValidSessions(Exception):

--- a/src/omemo/state.py
+++ b/src/omemo/state.py
@@ -178,7 +178,7 @@ class OmemoState:
                     sid))
                 return
 
-        result = decrypt(key, iv, payload)
+        result = unicode(decrypt(key, iv, payload))
         log.debug(u"Decrypted msg ⇒ " + result)
         return result
 
@@ -297,13 +297,13 @@ class OmemoState:
     def handlePreKeyWhisperMessage(self, recipient_id, device_id, key):
         preKeyWhisperMessage = PreKeyWhisperMessage(serialized=key)
         sessionCipher = self.get_session_cipher(recipient_id, device_id)
-        key = sessionCipher.decryptPkmsg(preKeyWhisperMessage, False)
+        key = sessionCipher.decryptPkmsg(preKeyWhisperMessage)
         log.debug('PreKeyWhisperMessage -> ' + str(key))
         return key
 
     def handleWhisperMessage(self, recipient_id, device_id, key):
         whisperMessage = WhisperMessage(serialized=key)
         sessionCipher = self.get_session_cipher(recipient_id, device_id)
-        key = sessionCipher.decryptMsg(whisperMessage, False)
+        key = sessionCipher.decryptMsg(whisperMessage)
         log.debug('WhisperMessage -> ' + str(key))
         return key

--- a/tests/test_omemo_state.py
+++ b/tests/test_omemo_state.py
@@ -156,7 +156,6 @@ def test_create_message():
         assert decodestring(key)
 
 
-@pytest.mark.skipif(True, reason="FIX THIS")
 def test_decrypt_message():
     romeo = omemo_state(db())
     julia = omemo_state(db())

--- a/tests/test_omemo_state.py
+++ b/tests/test_omemo_state.py
@@ -156,6 +156,7 @@ def test_create_message():
         assert decodestring(key)
 
 
+@pytest.mark.skipif(True, reason="FIX THIS")
 def test_decrypt_message():
     romeo = omemo_state(db())
     julia = omemo_state(db())

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ passenv =
     *
 deps =
     pytest
-    https://github.com/kalkin/python-axolotl/tarball/master#egg=python-axolotl-0.1.7-p1
+    python-axolotl
     pytest-travis-fold
     cover: pytest-cov
     crypto: cryptography

--- a/tox.ini
+++ b/tox.ini
@@ -57,8 +57,7 @@ commands =
 skip_install = true
 usedevelop = false
 deps =
-    https://github.com/kalkin/python-axolotl/tarball/master#egg=python-axolotl-0.1.7-p1
-    sphinx>=1.3
+    -r{toxinidir}/docs/requirements.txt
     sphinxcontrib-spelling
     pyenchant
 


### PR DESCRIPTION
- Patch axolotl.sessioncipher.SessionCipher decryptMsg & decryptPkmsg to work
  with byte data instead of strings
- Revert all the changes for the custom python-axolotl fork
